### PR TITLE
Post processing uniforms

### DIFF
--- a/assets/shaders/fragment_post.glsl
+++ b/assets/shaders/fragment_post.glsl
@@ -2,6 +2,7 @@
 out vec4 FragColor;
 
 uniform sampler2D mainImage;
+uniform float effect1;
 in vec2 texPosition;
 
 void main(void) {

--- a/configuration.json
+++ b/configuration.json
@@ -45,7 +45,15 @@
             "variableType": "track",
             "variable": "scene1Color",
             "dataType": "float3",
-            "track": "scene1.color"
+            "track": "scene1.color",
+            "shaderType": "main"
+        },
+        {
+            "variableType": "track",
+            "variable": "effect1",
+            "dataType": "float1",
+            "track": "scene1.effect",
+            "shaderType": "post"
         }
     ]
 }

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -70,9 +70,16 @@ namespace DemoSystem
                 double y;
                 double z;
             };
+            enum ShaderType 
+            {
+                MAIN,
+                POST,
+                ALL
+            };
             VariableType variableType;
             DataType type;
             Value initialValue;
+            ShaderType shaderType;
             std::string trackName;
             std::string variableName;
             bool persistent;

--- a/include/Graphics.h
+++ b/include/Graphics.h
@@ -22,7 +22,6 @@ namespace DemoSystem
         Graphics();
         ~Graphics();
         void initialize(Configuration::Shaders shaders, Configuration::Screen screen, Configuration::Demo demo);
-        void addUniforms();
 
         void registerSynchronizer(DemoSystem::Synchronizer *synchronizer);
         void registerTextures(std::list<Textures::Texture> *textures);

--- a/include/Synchronizer.h
+++ b/include/Synchronizer.h
@@ -20,7 +20,7 @@ namespace DemoSystem
         void initialize(double bpm, int rpb);
         bool connectPlayer(std::string host);
         void setFunctions(sync_cb *functions);
-        void update(double row);
+        void update(double time);
         void initializeTrackVariables(std::list<Configuration::Variable> trackVariables);
         void initializeBasicVariables();
         void cleanUp();

--- a/include/Variable.h
+++ b/include/Variable.h
@@ -35,6 +35,13 @@ namespace DemoSystem
             const sync_track *y;
             const sync_track *z;
         };
+        enum ShaderType
+        {
+            MAIN,
+            POST,
+            ALL
+        };
+        ShaderType shaderType;
         SyncTrack syncTrack;
     };
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -89,6 +89,19 @@ bool DemoSystem::Configuration::read(std::string file)
                 {
                     t.type = Variable::DataType::FLOAT3;
                 }
+                std::string shaderType = c["variables"][i]["shaderType"].asString();
+                if (shaderType == "main")
+                {
+                    t.shaderType = Variable::ShaderType::MAIN;
+                }
+                else if (shaderType == "post")
+                {
+                    t.shaderType = Variable::ShaderType::POST;
+                }
+                else if (shaderType == "all")
+                {
+                    t.shaderType = Variable::ShaderType::ALL;
+                }
                 t.variableName = c["variables"][i]["variable"].asString();
                 std::string variableType = c["variables"][i]["variableType"].asString();
                 t.trackName = c["variables"][i]["track"].asString();

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -29,6 +29,26 @@ void DemoSystem::Framebuffer::drawFBO() {
     glBindTexture(GL_TEXTURE_2D, this->fbo_texture);
     glUniform1i(this->uniform_mainImage, 0);
     glEnableVertexAttribArray(this->attribute_position_postproc);
+
+    // Tracked uniforms
+    for (auto tv = this->synchronizer->trackVariables.begin(); tv != this->synchronizer->trackVariables.end(); tv++)
+    {
+        if (tv->shaderType == TrackVariable::ShaderType::POST)
+        {
+            if (tv->type == Variable::DataType::FLOAT1)
+            {
+                glUniform1f(tv->uniform, (GLfloat)tv->value.x);
+            }
+            else if (tv->type == Variable::DataType::FLOAT2)
+            {
+                glUniform2f(tv->uniform, (GLfloat)tv->value.x, (GLfloat)tv->value.y);
+            }
+            else if (tv->type == Variable::DataType::FLOAT3)
+            {
+                glUniform3f(tv->uniform, (GLfloat)tv->value.x, (GLfloat)tv->value.y, (GLfloat)tv->value.z);
+            }
+        }
+    }
     
     glBindBuffer(GL_ARRAY_BUFFER, vbo_fbo_vertices);
     glVertexAttribPointer(
@@ -91,6 +111,7 @@ void DemoSystem::Framebuffer::generateFBO(unsigned int width, unsigned int heigh
 
 void DemoSystem::Framebuffer::addUniformsPost() 
 {
+    // PostProcessing specific uniforms
     const char* uniform_name;
     uniform_name = "position";
     this->attribute_position_postproc = glGetAttribLocation(this->program, uniform_name);
@@ -101,6 +122,14 @@ void DemoSystem::Framebuffer::addUniformsPost()
     this->uniform_mainImage = glGetUniformLocation(this->program, uniform_name);
     if (this->uniform_mainImage == -1) {
         this->logger->write(DemoSystem::Logger::ERR, "Could not bind uniform");
+    }
+    // Tracked uniforms
+    for (auto tv = this->synchronizer->trackVariables.begin(); tv != this->synchronizer->trackVariables.end(); tv++)
+    {
+        if (tv->shaderType == TrackVariable::ShaderType::POST)
+        {
+            tv->uniform = glGetUniformLocation(this->program, tv->name.c_str());
+        }
     }
 }
 

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -129,12 +129,6 @@ void DemoSystem::Graphics::registerLogger(Logger *logger)
     this->postprocessingShader.registerLogger(logger);
 }
 
-// Not used at the moment, as uniforms are added per shader program
-void DemoSystem::Graphics::addUniforms()
-{
-    //this->mainShader.addUniforms();
-}
-
 void DemoSystem::Graphics::swapBuffers()
 {
     glfwSwapBuffers(this->window);

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -94,6 +94,7 @@ void DemoSystem::Graphics::initialize(Configuration::Shaders shaders, Configurat
 void DemoSystem::Graphics::registerSynchronizer(DemoSystem::Synchronizer *synchronizer)
 {
     this->mainShader.registerSynchronizer(synchronizer);
+    this->postprocessingShader.registerSynchronizer(synchronizer);
 }
 
 void DemoSystem::Graphics::registerCamera(DemoSystem::Camera *camera)
@@ -128,10 +129,10 @@ void DemoSystem::Graphics::registerLogger(Logger *logger)
     this->postprocessingShader.registerLogger(logger);
 }
 
-// Not used at the moment, need to find a way to add uniforms to postprocessing too
+// Not used at the moment, as uniforms are added per shader program
 void DemoSystem::Graphics::addUniforms()
 {
-    this->mainShader.addUniforms();
+    //this->mainShader.addUniforms();
 }
 
 void DemoSystem::Graphics::swapBuffers()

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -36,7 +36,10 @@ void DemoSystem::Shader::addUniforms()
 {
     for (auto tv = this->synchronizer->trackVariables.begin(); tv != this->synchronizer->trackVariables.end(); tv++)
     {
-        tv->uniform = glGetUniformLocation(this->program, tv->name.c_str());
+        if (tv->shaderType == TrackVariable::ShaderType::MAIN)
+        {
+            tv->uniform = glGetUniformLocation(this->program, tv->name.c_str());
+        }
     }
 
     for (auto bv = this->synchronizer->basicVariables.begin(); bv != this->synchronizer->basicVariables.end(); bv++)
@@ -202,17 +205,20 @@ void DemoSystem::Shader::render(double time)
 
     for (auto tv = this->synchronizer->trackVariables.begin(); tv != this->synchronizer->trackVariables.end(); tv++)
     {
-        if (tv->type == Variable::DataType::FLOAT1)
+        if (tv->shaderType == TrackVariable::ShaderType::MAIN)
         {
-            glUniform1f(tv->uniform, (GLfloat)tv->value.x);
-        }
-        else if (tv->type == Variable::DataType::FLOAT2)
-        {
-            glUniform2f(tv->uniform, (GLfloat)tv->value.x, (GLfloat)tv->value.y);
-        }
-        else if (tv->type == Variable::DataType::FLOAT3)
-        {
-            glUniform3f(tv->uniform, (GLfloat)tv->value.x, (GLfloat)tv->value.y, (GLfloat)tv->value.z);
+            if (tv->type == Variable::DataType::FLOAT1)
+            {
+                glUniform1f(tv->uniform, (GLfloat)tv->value.x);
+            }
+            else if (tv->type == Variable::DataType::FLOAT2)
+            {
+                glUniform2f(tv->uniform, (GLfloat)tv->value.x, (GLfloat)tv->value.y);
+            }
+            else if (tv->type == Variable::DataType::FLOAT3)
+            {
+                glUniform3f(tv->uniform, (GLfloat)tv->value.x, (GLfloat)tv->value.y, (GLfloat)tv->value.z);
+            }
         }
     }
 

--- a/src/Synchronizer.cpp
+++ b/src/Synchronizer.cpp
@@ -90,6 +90,20 @@ void DemoSystem::Synchronizer::initializeTrackVariables(std::list<Configuration:
             variable.syncTrack.z = sync_get_track(this->device, (track.trackName + ".z").c_str());
             break;
         }
+        switch (track.shaderType)
+        {
+        case Configuration::Variable::ShaderType::MAIN:
+            variable.shaderType = TrackVariable::ShaderType::MAIN;
+            break;
+        
+        case Configuration::Variable::ShaderType::POST:
+            variable.shaderType = TrackVariable::ShaderType::POST;
+            break;
+        
+        case Configuration::Variable::ShaderType::ALL:
+            variable.shaderType = TrackVariable::ShaderType::ALL;
+            break;
+        }
         variable.name = track.variableName;
         this->trackVariables.push_back(variable);
     }

--- a/src/Synchronizer.cpp
+++ b/src/Synchronizer.cpp
@@ -37,9 +37,10 @@ void DemoSystem::Synchronizer::setFunctions(sync_cb *functions)
     this->functions = functions;
 }
 
-void DemoSystem::Synchronizer::update(double row)
+void DemoSystem::Synchronizer::update(double time)
 {
-    if (sync_update(this->device, (int)floor(row * this->rowRate), this->functions, &this->rowRate))
+    float row = time * this->rowRate;
+    if (sync_update(this->device, (int)floor(row), this->functions, &this->rowRate))
     {
         if (this->player == true)
         {


### PR DESCRIPTION
It is now possible to write configurable uniforms to post-processing shader through Rocket.

Also fixed a sync error with rocket, where time was used instead of row number on rocket update function.